### PR TITLE
Support macOS target

### DIFF
--- a/examples/loader/main.rs
+++ b/examples/loader/main.rs
@@ -1,6 +1,7 @@
 #[cfg(not(target_os = "linux"))]
+#[cfg(not(target_os = "macos"))]
 #[cfg(not(target_os = "windows"))]
-compile_error!("unsupported platform - only Linux & Windows are supported");
+compile_error!("unsupported platform - only Linux, macOS and Windows are supported");
 
 fn main() {
     let engine = build_engine();
@@ -43,6 +44,18 @@ pub fn build_engine() -> Engine {
                 "debug",
                 "examples",
                 "libdynamic_library.so",
+            ]))
+            .expect("failed to load plugin"),
+    );
+    #[cfg(target_os = "macos")]
+    engine.register_global_module(
+        loader
+            .load(std::path::PathBuf::from_iter([
+                env!("CARGO_MANIFEST_DIR"),
+                "target",
+                "debug",
+                "examples",
+                "libdynamic_library.dylib",
             ]))
             .expect("failed to load plugin"),
     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,9 @@
 #![warn(clippy::cargo)]
 
 #[cfg(not(target_os = "linux"))]
+#[cfg(not(target_os = "macos"))]
 #[cfg(not(target_os = "windows"))]
-compile_error!("unsupported platform - only Linux & Windows are supported");
+compile_error!("unsupported platform - only Linux, macOS and Windows are supported");
 
 /// Trait implementation to create objects that load plugins.
 pub mod loader;

--- a/src/loader/libloading.rs
+++ b/src/loader/libloading.rs
@@ -99,7 +99,7 @@ impl Loader for Libloading {
                 .map(libloading::Library::from)
             }
 
-            #[cfg(target_os = "windows")]
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
             {
                 libloading::Library::new(path.as_ref())
             }

--- a/src/module_resolvers/libloading.rs
+++ b/src/module_resolvers/libloading.rs
@@ -6,6 +6,8 @@ use crate::loader::Loader;
 
 #[cfg(target_os = "linux")]
 const DYLIB_EXTENSION: &str = "so";
+#[cfg(target_os = "macos")]
+const DYLIB_EXTENSION: &str = "dylib";
 #[cfg(target_os = "windows")]
 const DYLIB_EXTENSION: &str = "dll";
 


### PR DESCRIPTION
It was tested on macOS Ventura on M2 silicon. It builds correctly and examples run as expected.

Since libloading supports multiple unix targets, this could be extended to other BSD flavors if needed.