### PR TITLE
test: add dynamic library tests and coverage reports

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,3 +29,17 @@ jobs:
         with:
           components: clippy, rust-src
       - run: cargo clippy --tests -- -Dclippy::all -Dclippy::pedantic
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - run: cargo llvm-cov --all --lcov --output-path lcov.info
+      - uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,12 @@ libloading = [
     "dep:libloading",
 ] # enable module resolver & plugin loader using the libloading crate.
 
+# Used to test a real dynamic library in unit tests.
+[[example]]
+name = "test_plugin"
+crate-type = ["cdylib"]
+path = "tests/fixtures/plugin/lib.rs"
+
 [[example]]
 name = "dynamic_library"
 crate-type = ["cdylib"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![docs.rs](https://img.shields.io/docsrs/rhai-dylib)](https://docs.rs/rhai-dylib)
 [![License](https://img.shields.io/crates/l/rhai-dylib)](https://github.com/rhaiscript/rhai-dylib/blob/main/LICENSE-MIT)
 [![CI](https://github.com/rhaiscript/rhai-dylib/actions/workflows/checks.yml/badge.svg)](https://github.com/rhaiscript/rhai-dylib/actions/workflows/checks.yml)
+[![codecov](https://codecov.io/gh/rhaiscript/rhai-dylib/branch/main/graph/badge.svg)](https://codecov.io/gh/rhaiscript/rhai-dylib)
 
 This crate exposes a simple API to load `dylib` Rust crates in a [Rhai](https://rhai.rs/) engine using [Rhai modules](https://rhai.rs/book/rust/modules/index.html).
 You can generate your own library project for [Rhai](https://rhai.rs/) using [`cargo-generate`](https://github.com/cargo-generate/cargo-generate) with [`this template`](https://github.com/ltabis/rhai-dylib-template).

--- a/src/loader/libloading.rs
+++ b/src/loader/libloading.rs
@@ -133,3 +133,56 @@ impl Loader for Libloading {
         Ok(module_entrypoint())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::loader::Loader;
+
+    fn build_test_plugin() -> &'static std::path::PathBuf {
+        // Prevents multiple threads writing to the dll on windows and triggering a STATUS_ACCESS_VIOLATION error.
+        static PATH: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+        PATH.get_or_init(|| {
+            let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+            let status = std::process::Command::new("cargo")
+                .args(["build", "--example", "test_plugin"])
+                .current_dir(manifest_dir)
+                .status()
+                .expect("failed to execute cargo build");
+
+            assert!(status.success(), "building test_plugin failed");
+
+            let target_dir = std::env::var("CARGO_TARGET_DIR")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|_| manifest_dir.join("target"));
+
+            #[cfg(target_os = "linux")]
+            return target_dir.join("debug/examples/libtest_plugin.so");
+            #[cfg(target_os = "macos")]
+            return target_dir.join("debug/examples/libtest_plugin.dylib");
+            #[cfg(target_os = "windows")]
+            return target_dir.join("debug/examples/test_plugin.dll");
+        })
+    }
+
+    #[test]
+    fn new() {
+        let _ = Libloading::new();
+    }
+
+    #[test]
+    fn load_success() {
+        let mut loader = Libloading::new();
+        loader
+            .load(build_test_plugin().as_path())
+            .expect("failed to load test_plugin");
+    }
+
+    #[test]
+    fn load_nonexistent_returns_error() {
+        let mut loader = Libloading::new();
+        let err = loader.load("nonexistent.so").unwrap_err();
+
+        assert!(matches!(*err, rhai::EvalAltResult::ErrorInModule(..)));
+    }
+}

--- a/src/module_resolvers/libloading.rs
+++ b/src/module_resolvers/libloading.rs
@@ -13,12 +13,12 @@ const DYLIB_EXTENSION: &str = "dll";
 pub struct DylibModuleResolver {
     /// Path prepended for each import if specified.
     base_path: Option<std::path::PathBuf>,
-    /// Dynamic library loader.
-    loader: rhai::Locked<Libloading>,
     /// Is module caching enabled for this resolver.
     cache_enabled: bool,
     /// Cache of loaded modules, empty if [`Self::cache_enabled`] is false.
     cache: rhai::Locked<std::collections::BTreeMap<std::path::PathBuf, rhai::Shared<rhai::Module>>>,
+    /// Dynamic library loader.
+    loader: rhai::Locked<Libloading>,
 }
 
 impl Default for DylibModuleResolver {
@@ -182,6 +182,41 @@ impl rhai::ModuleResolver for DylibModuleResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rhai::ModuleResolver;
+
+    fn build_test_plugin() -> &'static std::path::PathBuf {
+        // Prevents multiple threads writing to the dll on windows and triggering a STATUS_ACCESS_VIOLATION error.
+        static PATH: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+        PATH.get_or_init(|| {
+            let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+            let status = std::process::Command::new("cargo")
+                .args(["build", "--example", "test_plugin"])
+                .current_dir(manifest_dir)
+                .status()
+                .expect("failed to execute cargo build");
+
+            assert!(status.success(), "building test_plugin failed");
+
+            let target_dir = std::env::var("CARGO_TARGET_DIR")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|_| manifest_dir.join("target"));
+
+            #[cfg(target_os = "linux")]
+            return target_dir.join("debug/examples/libtest_plugin.so");
+            #[cfg(target_os = "macos")]
+            return target_dir.join("debug/examples/libtest_plugin.dylib");
+            #[cfg(target_os = "windows")]
+            return target_dir.join("debug/examples/test_plugin.dll");
+        })
+    }
+
+    fn test_plugin_module_path() -> String {
+        build_test_plugin()
+            .with_extension("")
+            .to_str()
+            .unwrap()
+            .replace('\\', "/")
+    }
 
     #[test]
     fn new() {
@@ -235,5 +270,77 @@ mod tests {
             absolute,
             std::path::PathBuf::from("/usr/local/lib/mylib.so")
         );
+    }
+
+    #[test]
+    fn resolve_ast_returns_none() {
+        let r = DylibModuleResolver::new();
+        let engine = rhai::Engine::new();
+        assert!(r
+            .resolve_ast(&engine, None, "anything", rhai::Position::NONE)
+            .is_none());
+    }
+
+    #[test]
+    fn resolve_returns_error_for_missing_file() {
+        let r = DylibModuleResolver::new();
+        let engine = rhai::Engine::new();
+        assert!(r
+            .resolve(&engine, None, "nonexistent_module", rhai::Position::NONE)
+            .is_err());
+    }
+
+    #[test]
+    fn resolve_loads_module() {
+        let module_path = test_plugin_module_path();
+        let r = DylibModuleResolver::new();
+        let engine = rhai::Engine::new();
+        let module = r
+            .resolve(&engine, None, &module_path, rhai::Position::NONE)
+            .expect("failed to resolve module");
+        assert!(!module.is_empty());
+    }
+
+    #[test]
+    fn resolve_cache_hit_returns_same_module() {
+        let module_path = test_plugin_module_path();
+        let r = DylibModuleResolver::new();
+        let engine = rhai::Engine::new();
+        let m1 = r
+            .resolve(&engine, None, &module_path, rhai::Position::NONE)
+            .expect("first resolve failed");
+        let m2 = r
+            .resolve(&engine, None, &module_path, rhai::Position::NONE)
+            .expect("second resolve failed");
+
+        assert!(std::ptr::eq(&*m1, &*m2));
+    }
+
+    #[test]
+    fn resolve_without_cache() {
+        let module_path = test_plugin_module_path();
+        let mut r = DylibModuleResolver::new();
+
+        r.enable_cache(false);
+
+        let engine = rhai::Engine::new();
+
+        r.resolve(&engine, None, &module_path, rhai::Position::NONE)
+            .expect("resolve without cache failed");
+    }
+
+    #[test]
+    fn resolve_raw_via_engine_import() {
+        let module_path = test_plugin_module_path();
+        let _ = rhai::config::hashing::set_hashing_seed(Some([1, 2, 3, 4]));
+        let mut engine = rhai::Engine::new();
+
+        engine.set_module_resolver(DylibModuleResolver::new());
+
+        let result = engine
+            .eval::<rhai::INT>(&format!(r#"import "{module_path}" as p; p::add(1, 2)"#))
+            .expect("engine eval failed");
+
+        assert_eq!(result, 3);
     }
 }

--- a/src/module_resolvers/mod.rs
+++ b/src/module_resolvers/mod.rs
@@ -50,3 +50,16 @@ pub fn locked_read<T>(value: &'_ rhai::Locked<T>) -> LockGuard<'_, T> {
     #[cfg(feature = "sync")]
     return value.read().unwrap();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn locked_write_and_read() {
+        let value = rhai::Locked::new(0i32);
+
+        *locked_write(&value) = 42;
+        assert_eq!(*locked_read(&value), 42);
+    }
+}

--- a/tests/fixtures/plugin/lib.rs
+++ b/tests/fixtures/plugin/lib.rs
@@ -1,0 +1,12 @@
+use rhai_dylib::rhai::{config::hashing::set_hashing_seed, Module, Shared, INT};
+
+// A really simple plugin used as a real dynamic library in unit tests.
+#[allow(improper_ctypes_definitions)]
+#[no_mangle]
+pub extern "C" fn module_entrypoint() -> Shared<Module> {
+    let _ = set_hashing_seed(Some([1, 2, 3, 4]));
+    let mut module = Module::new();
+
+    module.set_native_fn("add", |a: INT, b: INT| Ok(a + b));
+    module.into()
+}


### PR DESCRIPTION
Compile a dynamic library using cargo build commands in unit tests to make real tests on plugins.
Add codecov configuration. Needs the app install though, and I don't have the permissions.